### PR TITLE
Improved math constants includes, improved imgui-sfml build, and fixed issue with hslColor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ configure_file (
   "${PROJECT_PATH}/MapgenConfig.h"
   )
 add_definitions(-DIMGUI_USER_CONFIG="include/imgui-sfml/imconfig-SFML.h")
-
+add_definitions(-D_USE_MATH_DEFINES)
 include_directories(
   ${PROJECT_PATH}
   ${LIBMAPGEN_PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ configure_file (
   "${PROJECT_SOURCE_DIR}/MapgenConfig.h.in"
   "${PROJECT_PATH}/MapgenConfig.h"
   )
+add_definitions(-DIMGUI_USER_CONFIG="include/imgui-sfml/imconfig-SFML.h")
 
 include_directories(
   ${PROJECT_PATH}

--- a/src/hslColor.cpp
+++ b/src/hslColor.cpp
@@ -121,7 +121,7 @@ HSL TurnToHSL(const sf::Color& C)
     if (max - min <= D_EPSILON )
     {
         A.Hue = 0;
-        A.Saturation = 0;
+        s = 0;
     }
     else
     {


### PR DESCRIPTION
Adding -DIMGUI_USER_CONFIG``` means that imconfig-SFML.h no longer needs to be copied into imconfig.h. imconfig-SFML.h doesn't seem to have any header guards, but I didn't have any issues running the app. 

hslColor was sometimes using an uninitalized value for saturation.

Adding -D_USE_MATH_DEFINES means that M_PI doesn't need to be defined in code on windows.